### PR TITLE
Add computation of calibrated airspeed

### DIFF
--- a/src/stdatm/atmosphere.py
+++ b/src/stdatm/atmosphere.py
@@ -335,31 +335,46 @@ class Atmosphere:
     def mach(self, value: Union[float, Sequence[float]]):
         self._reset_speeds()
         if value is not None:
-            self._mach = np.asarray(value)
+            self._mach = self._adapt_shape(value)
 
     @true_airspeed.setter
     def true_airspeed(self, value: Union[float, Sequence[float]]):
         self._reset_speeds()
         if value is not None:
-            self._true_airspeed = np.asarray(value)
+            self._true_airspeed = self._adapt_shape(value)
 
     @equivalent_airspeed.setter
     def equivalent_airspeed(self, value: Union[float, Sequence[float]]):
         self._reset_speeds()
         if value is not None:
-            self._equivalent_airspeed = np.asarray(value)
+            self._equivalent_airspeed = self._adapt_shape(value)
 
     @unitary_reynolds.setter
     def unitary_reynolds(self, value: Union[float, Sequence[float]]):
         self._reset_speeds()
         if value is not None:
-            self._unitary_reynolds = np.asarray(value)
+            self._unitary_reynolds = self._adapt_shape(value)
 
     @dynamic_pressure.setter
     def dynamic_pressure(self, value: Union[float, Sequence[float]]):
         self._reset_speeds()
         if value is not None:
-            self._dynamic_pressure = np.asarray(value)
+            self._dynamic_pressure = self._adapt_shape(value)
+
+    def _adapt_shape(self, value):
+        value = np.asarray(value)
+        try:
+            expected_shape = np.shape(value + self.get_altitude())
+        except ValueError as exc:
+            raise RuntimeError(
+                "Shape of provided value is not "
+                f"compatible with shape of altitude {np.shape(self.get_altitude())}."
+            ) from exc
+
+        if value.shape != expected_shape:
+            value = np.broadcast_to(value, expected_shape)
+
+        return value
 
     def _reset_speeds(self):
         """To be used before setting a new speed value as private attribute."""

--- a/src/stdatm/tests/test_atmosphere.py
+++ b/src/stdatm/tests/test_atmosphere.py
@@ -234,6 +234,14 @@ def run_speed_conversion_tests(with_broadcast: bool):
     atm.dynamic_pressure = Checker.expected_dynamic_pressure
     Checker.check_speeds(atm)
 
+    atm = Atmosphere(altitudes)
+    atm.impact_pressure = Checker.expected_impact_pressure
+    Checker.check_speeds(atm)
+
+    atm = Atmosphere(altitudes)
+    atm.calibrated_airspeed = Checker.expected_CAS
+    Checker.check_speeds(atm)
+
     # Check with one altitude value, but several speed values ############################
     atm = Atmosphere(35000)
     atm.true_airspeed = np.array(Checker.expected_TAS)[:, 2]

--- a/src/stdatm/tests/test_atmosphere.py
+++ b/src/stdatm/tests/test_atmosphere.py
@@ -19,6 +19,7 @@ import pytest
 from numpy.testing import assert_allclose
 from scipy.constants import foot
 
+from .. import AtmosphereSI
 from ..atmosphere import Atmosphere, AtmosphereSI
 
 
@@ -132,6 +133,22 @@ def test_atmosphere():
         # Additional check for get_altitude in feet
         assert expectations["alt"][idx] / foot == pytest.approx(atm.get_altitude(), rel=1e-3)
 
+        # Same with AtmosphereSI
+        atm = AtmosphereSI(alt, delta_t)
+        assert expectations["T"][idx] == pytest.approx(atm.temperature, rel=1e-4)
+        assert expectations["rho"][idx] == pytest.approx(atm.density, rel=1e-3)
+        assert expectations["P"][idx] == pytest.approx(atm.pressure, rel=1e-4)
+        assert expectations["visc"][idx] == pytest.approx(atm.kinematic_viscosity, rel=1e-2)
+        assert expectations["SoS"][idx] == pytest.approx(atm.speed_of_sound, rel=1e-3)
+        # Additional check for altitude property
+        assert expectations["alt"][idx] == pytest.approx(atm.altitude, rel=1e-3)
+
+
+def test_speed_parameters_basic():
+    atm = Atmosphere([0, 5000, 10000])
+    with pytest.raises(RuntimeError):
+        atm.true_airspeed = [[100, 200]]
+
 
 def test_speed_conversions_with_broadcast():
     """Tests for speed conversions with different but compatible shapes for altitude and TAS"""
@@ -180,6 +197,55 @@ def run_speed_conversion_tests(with_broadcast: bool):
             [340.294, 339.122, 296.536],
             [340.294, 339.122, 296.536],
         ]
+
+    atm = Atmosphere(altitudes)
+    assert atm.true_airspeed is None
+    assert atm.equivalent_airspeed is None
+    assert atm.mach is None
+    assert atm.unitary_reynolds is None
+
+    atm.true_airspeed = TAS
+    Checker.check_speeds(atm)
+
+    atm.true_airspeed = None
+    assert atm.true_airspeed is None
+    assert atm.equivalent_airspeed is None
+    assert atm.mach is None
+    assert atm.unitary_reynolds is None
+
+    atm = Atmosphere(altitudes)
+    atm.equivalent_airspeed = Checker.expected_EAS
+    Checker.check_speeds(atm)
+
+    # Here we do not instantiate a new Atmosphere, but simply modify Mach number.
+    # Other parameters should be modified accordingly.
+    atm.mach = 1.0
+    assert_allclose(atm.true_airspeed, speed_of_sound, rtol=1e-4)
+
+    atm = Atmosphere(altitudes)
+    atm.mach = Checker.expected_Mach
+    Checker.check_speeds(atm)
+
+    atm = Atmosphere(altitudes)
+    atm.unitary_reynolds = Checker.expected_Re1
+    Checker.check_speeds(atm)
+
+    atm = Atmosphere(altitudes)
+    atm.dynamic_pressure = Checker.expected_dynamic_pressure
+    Checker.check_speeds(atm)
+
+    # Check with one altitude value, but several speed values ############################
+    atm = Atmosphere(35000)
+    atm.true_airspeed = np.array(Checker.expected_TAS)[:, 2]
+    assert_allclose(atm.equivalent_airspeed, np.array(Checker.expected_EAS)[:, 2], rtol=1e-4)
+    assert_allclose(atm.mach, np.array(Checker.expected_Mach)[:, 2], rtol=1e-4)
+    assert_allclose(atm.unitary_reynolds, np.array(Checker.expected_Re1)[:, 2], rtol=1e-4)
+    assert_allclose(
+        atm.impact_pressure, np.array(Checker.expected_impact_pressure)[:, 2], rtol=1e-4
+    )
+
+
+class Checker:
     # source:  https://www.newbyte.co.il/calculator/index.php using "pressure altitude" as output.
     # This source, with "geometric altitude" as input, agrees with
     # http://www.aerospaceweb.org/design/scripts/atmosphere/
@@ -246,71 +312,16 @@ def run_speed_conversion_tests(with_broadcast: bool):
         [668493.9, 649486.1, 210939.7],
     ]
 
-    atm = Atmosphere(altitudes)
-    assert atm.true_airspeed is None
-    assert atm.equivalent_airspeed is None
-    assert atm.mach is None
-    assert atm.unitary_reynolds is None
+    @classmethod
+    def check_speeds(cls, atm, tol=1e-4):
 
-    atm.true_airspeed = TAS
-    assert_allclose(atm.equivalent_airspeed, expected_EAS, rtol=1e-4)
-    print(atm.calibrated_airspeed)
-    assert_allclose(atm.calibrated_airspeed, expected_CAS, rtol=1e-4)
-    assert_allclose(atm.mach, expected_Mach, rtol=1e-4)
-    assert_allclose(atm.unitary_reynolds, expected_Re1, rtol=1e-4)
-    assert_allclose(atm.dynamic_pressure, expected_dynamic_pressure, rtol=1e-4)
-    assert_allclose(atm.impact_pressure, expected_impact_pressure, rtol=1e-4)
-
-    atm.true_airspeed = None
-    assert atm.true_airspeed is None
-    assert atm.equivalent_airspeed is None
-    assert atm.mach is None
-    assert atm.unitary_reynolds is None
-
-    atm = Atmosphere(altitudes)
-    atm.equivalent_airspeed = expected_EAS
-    assert_allclose(atm.true_airspeed, expected_TAS, rtol=1e-4)
-    assert_allclose(atm.mach, expected_Mach, rtol=1e-4)
-    assert_allclose(atm.unitary_reynolds, expected_Re1, rtol=1e-4)
-    assert_allclose(atm.dynamic_pressure, expected_dynamic_pressure, rtol=1e-4)
-    assert_allclose(atm.impact_pressure, expected_impact_pressure, rtol=1e-4)
-
-    # Here we do not instantiate a new Atmosphere, but simply modify Mach number.
-    # Other parameters should be modified accordingly.
-    atm.mach = 1.0
-    assert_allclose(atm.true_airspeed, speed_of_sound, rtol=1e-4)
-
-    atm = Atmosphere(altitudes)
-    atm.mach = expected_Mach
-    assert_allclose(atm.true_airspeed, expected_TAS, rtol=1e-4)
-    assert_allclose(atm.equivalent_airspeed, expected_EAS, rtol=1e-4)
-    assert_allclose(atm.unitary_reynolds, expected_Re1, rtol=1e-4)
-    assert_allclose(atm.dynamic_pressure, expected_dynamic_pressure, rtol=1e-4)
-    assert_allclose(atm.impact_pressure, expected_impact_pressure, rtol=1e-4)
-
-    atm = Atmosphere(altitudes)
-    atm.unitary_reynolds = expected_Re1
-    assert_allclose(atm.true_airspeed, expected_TAS, rtol=1e-4)
-    assert_allclose(atm.equivalent_airspeed, expected_EAS, rtol=1e-4)
-    assert_allclose(atm.mach, expected_Mach, rtol=1e-4)
-    assert_allclose(atm.dynamic_pressure, expected_dynamic_pressure, rtol=1e-4)
-    assert_allclose(atm.impact_pressure, expected_impact_pressure, rtol=1e-4)
-
-    atm = Atmosphere(altitudes)
-    atm.dynamic_pressure = expected_dynamic_pressure
-    assert_allclose(atm.true_airspeed, expected_TAS, rtol=1e-4)
-    assert_allclose(atm.equivalent_airspeed, expected_EAS, rtol=1e-4)
-    assert_allclose(atm.mach, expected_Mach, rtol=1e-4)
-    assert_allclose(atm.unitary_reynolds, expected_Re1, rtol=1e-4)
-    assert_allclose(atm.impact_pressure, expected_impact_pressure, rtol=1e-4)
-
-    # Check with one altitude value, but several speed values ############################
-    atm = Atmosphere(35000)
-    atm.true_airspeed = np.array(expected_TAS)[:, 2]
-    assert_allclose(atm.equivalent_airspeed, np.array(expected_EAS)[:, 2], rtol=1e-4)
-    assert_allclose(atm.mach, np.array(expected_Mach)[:, 2], rtol=1e-4)
-    assert_allclose(atm.unitary_reynolds, np.array(expected_Re1)[:, 2], rtol=1e-4)
-    assert_allclose(atm.impact_pressure, np.array(expected_impact_pressure)[:, 2], rtol=1e-4)
+        assert_allclose(atm.true_airspeed, cls.expected_TAS, rtol=tol)
+        assert_allclose(atm.equivalent_airspeed, cls.expected_EAS, rtol=tol)
+        assert_allclose(atm.calibrated_airspeed, cls.expected_CAS, rtol=tol)
+        assert_allclose(atm.mach, cls.expected_Mach, rtol=tol)
+        assert_allclose(atm.unitary_reynolds, cls.expected_Re1, rtol=tol)
+        assert_allclose(atm.dynamic_pressure, cls.expected_dynamic_pressure, rtol=tol)
+        assert_allclose(atm.impact_pressure, cls.expected_impact_pressure, rtol=tol)
 
 
 @pytest.fixture(scope="session")

--- a/src/stdatm/tests/test_atmosphere.py
+++ b/src/stdatm/tests/test_atmosphere.py
@@ -197,7 +197,6 @@ def run_speed_conversion_tests(with_broadcast: bool):
         [400.0, 400.0, 400.0],
         [800.0, 800.0, 800.0],
     ]
-
     expected_EAS = [
         [100.0, 98.543, 55.666],
         [200.0, 197.085, 111.333],
@@ -206,13 +205,13 @@ def run_speed_conversion_tests(with_broadcast: bool):
         [400, 394.170, 222.666],
         [800, 788.341, 445.332],
     ]
-    expected_CAS = [  # currently unused
+    expected_CAS = [
         [100.0, 98.580, 56.269],
         [200.0, 197.362, 116.073],
         [270, 266.698, 161.732],
         [300.0, 296.465, 182.507],
         [400, 395.578, 252.396],
-        [800, 789.350, 479.5671],
+        [800, 789.350, 479.567],
     ]
     expected_Mach = [
         [0.29386, 0.29488, 0.33723],
@@ -255,6 +254,8 @@ def run_speed_conversion_tests(with_broadcast: bool):
 
     atm.true_airspeed = TAS
     assert_allclose(atm.equivalent_airspeed, expected_EAS, rtol=1e-4)
+    print(atm.calibrated_airspeed)
+    assert_allclose(atm.calibrated_airspeed, expected_CAS, rtol=1e-4)
     assert_allclose(atm.mach, expected_Mach, rtol=1e-4)
     assert_allclose(atm.unitary_reynolds, expected_Re1, rtol=1e-4)
     assert_allclose(atm.dynamic_pressure, expected_dynamic_pressure, rtol=1e-4)

--- a/src/stdatm/tests/test_atmosphere.py
+++ b/src/stdatm/tests/test_atmosphere.py
@@ -192,6 +192,23 @@ def test_speed_conversions():
         [27383763, 26734454, 10592556],
         [54767527, 53468908, 21185111],
     ]
+    expected_dynamic_pressure = [
+        [6125.0, 5947.8, 1898.0],
+        [24500.0, 23791.1, 7591.9],
+        [44651.2, 43359.2, 13836.3],
+        [55125.0, 53529.9, 17081.9],
+        [97999.9, 95164.2, 30367.8],
+        [391999.7, 380656.9, 121471.0],
+    ]
+    expected_impact_pressure = [
+        [6258.4, 6078.2, 1952.6],
+        [26689.4, 25932.3, 8495.0],
+        [52127.8, 50672.8, 16946.6],
+        [66684.1, 64838.1, 21911.2],
+        [135479.4, 131780.5, 44684.1],
+        [668493.9, 649486.1, 210939.7],
+    ]
+
     speed_of_sound = [
         [340.294, 339.122, 296.536],
         [340.294, 339.122, 296.536],
@@ -211,6 +228,7 @@ def test_speed_conversions():
     assert_allclose(atm.equivalent_airspeed, expected_EAS, rtol=1e-4)
     assert_allclose(atm.mach, expected_Mach, rtol=1e-4)
     assert_allclose(atm.unitary_reynolds, expected_Re1, rtol=1e-4)
+    assert_allclose(atm.dynamic_pressure, expected_dynamic_pressure, rtol=1e-4)
 
     atm.true_airspeed = None
     assert atm.true_airspeed is None
@@ -223,6 +241,7 @@ def test_speed_conversions():
     assert_allclose(atm.true_airspeed, TAS, rtol=1e-4)
     assert_allclose(atm.mach, expected_Mach, rtol=1e-4)
     assert_allclose(atm.unitary_reynolds, expected_Re1, rtol=1e-4)
+    assert_allclose(atm.dynamic_pressure, expected_dynamic_pressure, rtol=1e-4)
 
     # Here we do not instantiate a new Atmosphere, but simply modify Mach number.
     # Other parameters should be modified accordingly
@@ -234,14 +253,23 @@ def test_speed_conversions():
     assert_allclose(atm.true_airspeed, TAS, rtol=1e-4)
     assert_allclose(atm.equivalent_airspeed, expected_EAS, rtol=1e-4)
     assert_allclose(atm.unitary_reynolds, expected_Re1, rtol=1e-4)
+    assert_allclose(atm.dynamic_pressure, expected_dynamic_pressure, rtol=1e-4)
 
     atm = Atmosphere(altitudes)
     atm.unitary_reynolds = expected_Re1
     assert_allclose(atm.true_airspeed, TAS, rtol=1e-4)
     assert_allclose(atm.equivalent_airspeed, expected_EAS, rtol=1e-4)
     assert_allclose(atm.mach, expected_Mach, rtol=1e-4)
+    assert_allclose(atm.dynamic_pressure, expected_dynamic_pressure, rtol=1e-4)
 
-    # Check with one altitude value, but several speed values
+    atm = Atmosphere(altitudes)
+    atm.dynamic_pressure = expected_dynamic_pressure
+    assert_allclose(atm.true_airspeed, TAS, rtol=1e-4)
+    assert_allclose(atm.equivalent_airspeed, expected_EAS, rtol=1e-4)
+    assert_allclose(atm.mach, expected_Mach, rtol=1e-4)
+    assert_allclose(atm.unitary_reynolds, expected_Re1, rtol=1e-4)
+
+    # Check with one altitude value, but several speed values ############################
     atm = Atmosphere(35000)
     atm.true_airspeed = np.array(TAS)[:, 2]
     assert_allclose(atm.equivalent_airspeed, np.array(expected_EAS)[:, 2], rtol=1e-4)


### PR DESCRIPTION
This PR adds the following parameters to Atmosphere class:
- `dynamic_pressure` : Theoretical (true) dynamic pressure
- `impact_pressure` : Compressible dynamic pressure (used to get CAS)
- `calibrated_airspeed`