### PR TITLE
Enhancing CPU performances for scalar altitudes

### DIFF
--- a/.run/pytest benchmark in src.run.xml
+++ b/.run/pytest benchmark in src.run.xml
@@ -14,7 +14,7 @@
   -->
 
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="pytest in src" type="tests" factoryName="py.test" nameIsGenerated="true">
+  <configuration default="false" name="pytest benchmark in src" type="tests" factoryName="py.test">
     <module name="StdAtm" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
@@ -25,7 +25,7 @@
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <option name="_new_keywords" value="&quot;&quot;" />
     <option name="_new_parameters" value="&quot;&quot;" />
-    <option name="_new_additionalArguments" value="&quot;--no-cov&quot;" />
+    <option name="_new_additionalArguments" value="&quot;--no-cov --benchmark-enable&quot;" />
     <option name="_new_target" value="&quot;$PROJECT_DIR$/src&quot;" />
     <option name="_new_targetType" value="&quot;PATH&quot;" />
     <method v="2" />

--- a/.run/pytest benchmark in src.run.xml
+++ b/.run/pytest benchmark in src.run.xml
@@ -19,7 +19,7 @@
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <option name="SDK_HOME" value="" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/src/stdatm/tests" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />

--- a/src/stdatm/atmosphere.py
+++ b/src/stdatm/atmosphere.py
@@ -24,6 +24,7 @@ from scipy.optimize import fsolve
 
 from stdatm.state_parameters import (
     compute_density,
+    compute_kinematic_viscosity,
     compute_pressure,
     compute_temperature,
 )
@@ -169,10 +170,7 @@ class Atmosphere:
     def kinematic_viscosity(self) -> Union[float, np.ndarray]:
         """Kinematic viscosity in m2/s."""
         if self._kinematic_viscosity is None:
-            self._kinematic_viscosity = (
-                (0.000017894 * (self.temperature / SEA_LEVEL_TEMPERATURE) ** (3 / 2))
-                * ((SEA_LEVEL_TEMPERATURE + 110.4) / (self.temperature + 110.4))
-            ) / self.density
+            self._kinematic_viscosity = compute_kinematic_viscosity(self.temperature, self.density)
         return self._kinematic_viscosity
 
     @property

--- a/src/stdatm/atmosphere.py
+++ b/src/stdatm/atmosphere.py
@@ -13,6 +13,7 @@ Simple implementation of International Standard Atmosphere.
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 from copy import deepcopy
 from numbers import Number
 from typing import Sequence, Union
@@ -21,7 +22,11 @@ import numpy as np
 from scipy.constants import R, atmosphere, foot
 from scipy.optimize import fsolve
 
-from stdatm.state_parameters import compute_pressure, compute_temperature
+from stdatm.state_parameters import (
+    compute_density,
+    compute_pressure,
+    compute_temperature,
+)
 
 AIR_MOLAR_MASS = 28.9647e-3
 AIR_GAS_CONSTANT = R / AIR_MOLAR_MASS
@@ -150,7 +155,7 @@ class Atmosphere:
     def density(self) -> Union[float, np.ndarray]:
         """Density in kg/m3."""
         if self._density is None:
-            self._density = self.pressure / AIR_GAS_CONSTANT / self.temperature
+            self._density = compute_density(self.pressure, self.temperature)
         return self._density
 
     @property

--- a/src/stdatm/atmosphere.py
+++ b/src/stdatm/atmosphere.py
@@ -26,6 +26,7 @@ from stdatm.state_parameters import (
     compute_density,
     compute_kinematic_viscosity,
     compute_pressure,
+    compute_speed_of_sound,
     compute_temperature,
 )
 
@@ -163,7 +164,7 @@ class Atmosphere:
     def speed_of_sound(self) -> Union[float, np.ndarray]:
         """Speed of sound in m/s."""
         if self._speed_of_sound is None:
-            self._speed_of_sound = (1.4 * AIR_GAS_CONSTANT * self.temperature) ** 0.5
+            self._speed_of_sound = compute_speed_of_sound(self.temperature)
         return self._speed_of_sound
 
     @property

--- a/src/stdatm/speed_parameters.py
+++ b/src/stdatm/speed_parameters.py
@@ -1,0 +1,12 @@
+#  This file is part of StdAtm
+#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  StdAtm is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/src/stdatm/state_parameters.py
+++ b/src/stdatm/state_parameters.py
@@ -1,0 +1,89 @@
+"""Functions for computation of atmosphere state parameters."""
+#  This file is part of StdAtm
+#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  StdAtm is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from functools import lru_cache, singledispatch
+from numbers import Number
+from typing import Sequence
+
+import numpy as np
+from scipy.constants import R, atmosphere
+
+AIR_MOLAR_MASS = 28.9647e-3
+AIR_GAS_CONSTANT = R / AIR_MOLAR_MASS
+SEA_LEVEL_PRESSURE = atmosphere
+SEA_LEVEL_TEMPERATURE = 288.15
+TROPOPAUSE = 11000.0
+
+
+# TEMPERATURE =================================================================
+@singledispatch
+def compute_temperature(altitude: Sequence[float], delta_t: Number) -> np.ndarray:
+    """
+
+    :param altitude: in m
+    :param delta_t: in K
+    :return: Temperature in K
+    """
+    # Implementation for numpy arrays
+    altitude = np.asarray(altitude)
+    idx_tropo = altitude < TROPOPAUSE
+    idx_strato = np.logical_not(idx_tropo)
+
+    temperature = np.empty_like(altitude)
+    temperature[idx_tropo] = SEA_LEVEL_TEMPERATURE - 0.0065 * altitude[idx_tropo] + delta_t
+    temperature[idx_strato] = 216.65 + delta_t
+
+    return temperature
+
+
+@compute_temperature.register
+@lru_cache
+def _(altitude: Number, delta_t: Number) -> float:
+    # Implementation for floats
+    if altitude < TROPOPAUSE:
+        temperature = SEA_LEVEL_TEMPERATURE - 0.0065 * altitude + delta_t
+    else:
+        temperature = 216.65 + delta_t
+    return temperature
+
+
+# PRESSURE =================================================================
+@singledispatch
+def compute_pressure(altitude: Sequence[float]) -> np.ndarray:
+    """
+
+    :param altitude: in m
+    :return: pressure in Pa
+    """
+    # Implementation for numpy arrays
+    altitude = np.asarray(altitude)
+    idx_tropo = altitude < TROPOPAUSE
+    idx_strato = np.logical_not(idx_tropo)
+
+    pressure = np.empty_like(altitude)
+    pressure[idx_tropo] = SEA_LEVEL_PRESSURE * (1 - (altitude[idx_tropo] / 44330.78)) ** 5.25587611
+    pressure[idx_strato] = 22632 * 2.718281 ** (1.7345725 - 0.0001576883 * altitude[idx_strato])
+
+    return pressure
+
+
+@compute_pressure.register
+@lru_cache
+def _(altitude: Number) -> float:
+    # Implementation for floats
+    if altitude < TROPOPAUSE:
+        pressure = SEA_LEVEL_PRESSURE * (1 - (altitude / 44330.78)) ** 5.25587611
+    else:
+        pressure = 22632 * 2.718281 ** (1.7345725 - 0.0001576883 * altitude)
+    return pressure

--- a/src/stdatm/state_parameters.py
+++ b/src/stdatm/state_parameters.py
@@ -48,7 +48,7 @@ def compute_temperature(altitude, delta_t) -> np.ndarray:
 
 
 @compute_temperature.register
-@lru_cache
+@lru_cache()
 def _(altitude: Number, delta_t: Number) -> float:
     # Implementation for floats
     if altitude < TROPOPAUSE:
@@ -78,7 +78,7 @@ def compute_pressure(altitude) -> np.ndarray:
 
 
 @compute_pressure.register
-@lru_cache
+@lru_cache()
 def _(altitude: Number) -> float:
     # Implementation for floats
     if altitude < TROPOPAUSE:

--- a/src/stdatm/state_parameters.py
+++ b/src/stdatm/state_parameters.py
@@ -101,3 +101,14 @@ def compute_density(
     """
     density = pressure / AIR_GAS_CONSTANT / temperature
     return density
+
+
+# KINEMATIC VISCOSITY =================================================
+def compute_kinematic_viscosity(
+    temperature: Union[np.ndarray, Number], density: Union[np.ndarray, Number]
+) -> Union[np.ndarray, Number]:
+    kinematic_viscosity = (
+        (0.000017894 * (temperature / SEA_LEVEL_TEMPERATURE) ** (3 / 2))
+        * ((SEA_LEVEL_TEMPERATURE + 110.4) / (temperature + 110.4))
+    ) / density
+    return kinematic_viscosity

--- a/src/stdatm/state_parameters.py
+++ b/src/stdatm/state_parameters.py
@@ -14,7 +14,7 @@
 
 from functools import lru_cache, singledispatch
 from numbers import Number
-from typing import Sequence
+from typing import Sequence, Union
 
 import numpy as np
 from scipy.constants import R, atmosphere
@@ -87,3 +87,17 @@ def _(altitude: Number) -> float:
     else:
         pressure = 22632 * 2.718281 ** (1.7345725 - 0.0001576883 * altitude)
     return pressure
+
+
+# DENSITY =================================================================
+def compute_density(
+    pressure: Union[np.ndarray, Number], temperature: Union[np.ndarray, Number]
+) -> Union[np.ndarray, Number]:
+    """
+
+    :param pressure: in Pa
+    :param temperature: in K
+    :return: air density in kg/m**3
+    """
+    density = pressure / AIR_GAS_CONSTANT / temperature
+    return density

--- a/src/stdatm/state_parameters.py
+++ b/src/stdatm/state_parameters.py
@@ -12,9 +12,10 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 from functools import lru_cache, singledispatch
 from numbers import Number
-from typing import Sequence, Union
+from typing import Union
 
 import numpy as np
 from scipy.constants import R, atmosphere
@@ -28,7 +29,7 @@ TROPOPAUSE = 11000.0
 
 # TEMPERATURE =================================================================
 @singledispatch
-def compute_temperature(altitude: Sequence[float], delta_t: Number) -> np.ndarray:
+def compute_temperature(altitude, delta_t) -> np.ndarray:
     """
 
     :param altitude: in m
@@ -36,7 +37,6 @@ def compute_temperature(altitude: Sequence[float], delta_t: Number) -> np.ndarra
     :return: Temperature in K
     """
     # Implementation for numpy arrays
-    altitude = np.asarray(altitude)
     idx_tropo = altitude < TROPOPAUSE
     idx_strato = np.logical_not(idx_tropo)
 
@@ -60,14 +60,13 @@ def _(altitude: Number, delta_t: Number) -> float:
 
 # PRESSURE =================================================================
 @singledispatch
-def compute_pressure(altitude: Sequence[float]) -> np.ndarray:
+def compute_pressure(altitude) -> np.ndarray:
     """
 
     :param altitude: in m
     :return: pressure in Pa
     """
     # Implementation for numpy arrays
-    altitude = np.asarray(altitude)
     idx_tropo = altitude < TROPOPAUSE
     idx_strato = np.logical_not(idx_tropo)
 
@@ -100,6 +99,17 @@ def compute_density(
     :return: air density in kg/m**3
     """
     density = pressure / AIR_GAS_CONSTANT / temperature
+    return density
+
+
+# SPEED OF SOUND =================================================
+def compute_speed_of_sound(temperature: Union[np.ndarray, Number]) -> Union[np.ndarray, Number]:
+    """
+
+    :param temperature: in K
+    :return: in m/s
+    """
+    density = (1.4 * AIR_GAS_CONSTANT * temperature) ** 0.5
     return density
 
 

--- a/src/stdatm/tests/test_atmosphere.py
+++ b/src/stdatm/tests/test_atmosphere.py
@@ -1,6 +1,6 @@
 """Tests for Atmosphere class"""
 #  This file is part of StdAtm
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
 #  StdAtm is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -334,124 +334,122 @@ class Checker:
 
 @pytest.fixture(scope="session")
 def altitude():
-    return np.linspace(0.0, 20000.0, int(5e7))
+    return np.linspace(0.0, 20000.0, int(1e6))
 
 
-@pytest.fixture(scope="session")
-def atmosphere1(altitude):
+def get_atmosphere(altitude):
     atm = AtmosphereSI(altitude)
     atm.true_airspeed = 200.0
     return atm
 
 
-def test_performances_temperature_array(atmosphere1, benchmark):
+def test_performances_temperature_array(altitude, benchmark):
     def func():
-        _ = atmosphere1.temperature
+        atm = get_atmosphere(altitude)
+        _ = atm.temperature
 
     benchmark(func)
 
 
-def test_performances_pressure_array(atmosphere1, benchmark):
+def test_performances_pressure_array(altitude, benchmark):
     def func():
-        _ = atmosphere1.pressure
+        atm = get_atmosphere(altitude)
+        _ = atm.pressure
 
     benchmark(func)
 
 
-def test_performances_density_array(atmosphere1, benchmark):
+def test_performances_density_array(altitude, benchmark):
     def func():
-        _ = atmosphere1.density
+        atm = get_atmosphere(altitude)
+        _ = atm.density
 
     benchmark(func)
 
 
-def test_performances_kinematic_viscosity_array(atmosphere1, benchmark):
+def test_performances_kinematic_viscosity_array(altitude, benchmark):
     def func():
-        _ = atmosphere1.kinematic_viscosity
+        atm = get_atmosphere(altitude)
+        _ = atm.kinematic_viscosity
 
     benchmark(func)
 
 
-def test_performances_speed_of_sound_array(atmosphere1, benchmark):
+def test_performances_speed_of_sound_array(altitude, benchmark):
     def func():
-        _ = atmosphere1.speed_of_sound
+        atm = get_atmosphere(altitude)
+        _ = atm.speed_of_sound
 
     benchmark(func)
 
 
-def test_performances_TAS_1_array(atmosphere1, benchmark):
+def test_performances_TAS_array(altitude, benchmark):
     def func():
-        _ = atmosphere1.true_airspeed
+        atm = get_atmosphere(altitude)
+        _ = atm.true_airspeed
 
     benchmark(func)
 
 
-def test_performances_EAS_1_array(atmosphere1, benchmark):
+def test_performances_EAS_array(altitude, benchmark):
     def func():
-        _ = atmosphere1.equivalent_airspeed
+        atm = get_atmosphere(altitude)
+        _ = atm.equivalent_airspeed
 
     benchmark(func)
 
 
-def test_performances_mach_1_array(atmosphere1, benchmark):
+def test_performances_CAS_array(altitude, benchmark):
     def func():
-        _ = atmosphere1.mach
+        atm = get_atmosphere(altitude)
+        _ = atm.calibrated_airspeed
 
     benchmark(func)
 
 
-def test_performances_unit_Re_1_array(atmosphere1, benchmark):
+def test_performances_mach_array(altitude, benchmark):
     def func():
-        _ = atmosphere1.unitary_reynolds
+        atm = get_atmosphere(altitude)
+        _ = atm.mach
 
     benchmark(func)
 
 
-def test_performances_TAS_2_array(atmosphere1, benchmark):
+def test_performances_unit_Re_array(altitude, benchmark):
     def func():
-        _ = atmosphere1.true_airspeed
-
-    atmosphere1.true_airspeed = 500.0
-    benchmark(func)
-
-
-def test_performances_EAS_2_array(atmosphere1, benchmark):
-    def func():
-        _ = atmosphere1.equivalent_airspeed
+        atm = get_atmosphere(altitude)
+        _ = atm.unitary_reynolds
 
     benchmark(func)
 
 
-def test_performances_mach_2_array(atmosphere1, benchmark):
+def test_performances_reask_array(altitude, benchmark):
+    atm = get_atmosphere(altitude)
+    _ = atm.temperature
+    _ = atm.pressure
+    _ = atm.density
+    _ = atm.kinematic_viscosity
+    _ = atm.speed_of_sound
+    _ = atm.true_airspeed
+    _ = atm.equivalent_airspeed
+    _ = atm.mach
+    _ = atm.unitary_reynolds
+
     def func():
-        _ = atmosphere1.mach
+        _ = atm.temperature
+        _ = atm.pressure
+        _ = atm.density
+        _ = atm.kinematic_viscosity
+        _ = atm.speed_of_sound
+        _ = atm.true_airspeed
+        _ = atm.equivalent_airspeed
+        _ = atm.mach
+        _ = atm.unitary_reynolds
 
     benchmark(func)
 
 
-def test_performances_unit_Re_2_array(atmosphere1, benchmark):
-    def func():
-        _ = atmosphere1.unitary_reynolds
-
-    benchmark(func)
-
-
-def test_performances_reask_array(atmosphere1, benchmark):
-    def func():
-        _ = atmosphere1.temperature
-        _ = atmosphere1.pressure
-        _ = atmosphere1.density
-        _ = atmosphere1.kinematic_viscosity
-        _ = atmosphere1.speed_of_sound
-        _ = atmosphere1.true_airspeed
-        _ = atmosphere1.equivalent_airspeed
-        _ = atmosphere1.mach
-        _ = atmosphere1.unitary_reynolds
-
-    benchmark(func)
-
-
-def test_performances_loop_static(altitude, benchmark):
+def test_performances_loop_state_params(altitude, benchmark):
     def func():
         for alt in altitude[::1000]:
             atm = AtmosphereSI(alt)
@@ -494,7 +492,7 @@ def test_performances_loop_speeds_init_mach(altitude, benchmark):
 
 def test_performances_loop_CAS_init_TAS(altitude, benchmark):
     def func():
-        for alt in altitude[::2000]:
+        for alt in altitude[::1000]:
             atm = AtmosphereSI(alt)
             atm.true_airspeed = 100.0
             _ = atm.calibrated_airspeed
@@ -504,7 +502,7 @@ def test_performances_loop_CAS_init_TAS(altitude, benchmark):
 
 def test_performances_loop_CAS_init_mach(altitude, benchmark):
     def func():
-        for alt in altitude[::2000]:
+        for alt in altitude[::1000]:
             atm = AtmosphereSI(alt)
             atm.mach = 0.3
             _ = atm.calibrated_airspeed
@@ -514,7 +512,7 @@ def test_performances_loop_CAS_init_mach(altitude, benchmark):
 
 def test_performances_loop_TAS_init_CAS(altitude, benchmark):
     def func():
-        for alt in altitude[::20000]:
+        for alt in altitude[::10000]:
             atm = AtmosphereSI(alt)
             atm.calibrated_airspeed = 100.0
             _ = atm.true_airspeed


### PR DESCRIPTION
This PR enhances the CPU performances when using scalar altitude values as input instead of arrays.

The proposed solution is the usage of `functools.singledispatch` on state parameters.

A similar solution should be later implemented for speed parameters.