### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Version 0.3.1
+=============
+- Fixed:
+    - speed values were converted to numpy arrays, even if provided as scalars. (#17)
 
 Version 0.3.0
 =============

--- a/src/stdatm/atmosphere.py
+++ b/src/stdatm/atmosphere.py
@@ -15,7 +15,7 @@ Simple implementation of International Standard Atmosphere.
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from copy import deepcopy
-from numbers import Number
+from numbers import Number, Real
 from typing import Sequence, Union
 
 import numpy as np
@@ -316,6 +316,9 @@ class Atmosphere:
         return self._adapt_shape(value)
 
     def _adapt_shape(self, value):
+        if isinstance(value, Real):
+            return value
+
         if value is not None:
             value = np.asarray(value)
             if np.size(value) > 1:

--- a/src/stdatm/atmosphere.py
+++ b/src/stdatm/atmosphere.py
@@ -15,7 +15,7 @@ Simple implementation of International Standard Atmosphere.
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from copy import deepcopy
-from numbers import Number, Real
+from numbers import Real
 from typing import Sequence, Union
 
 import numpy as np
@@ -116,7 +116,7 @@ class Atmosphere:
 
         # For convenience, let's have altitude as numpy arrays and in meters in all cases
         unit_coeff = foot if altitude_in_feet else 1.0
-        if not isinstance(altitude, Number):
+        if not isinstance(altitude, Real):
             altitude = np.asarray(altitude)
         self._altitude = altitude * unit_coeff
 
@@ -153,7 +153,7 @@ class Atmosphere:
     @delta_t.setter
     def delta_t(self, value: float):
         # Let's ensure it is not a one-element array that would crash lru_cache
-        if isinstance(value, Number):
+        if isinstance(value, Real):
             self._delta_t = value
         else:
             self._delta_t = np.asarray(value).item()

--- a/src/stdatm/tests/test_atmosphere.py
+++ b/src/stdatm/tests/test_atmosphere.py
@@ -156,6 +156,10 @@ def test_speed_parameters_basic():
     with pytest.raises(RuntimeError):
         atm.true_airspeed = [[100, 200]]
 
+    atm = Atmosphere(10000.0)
+    atm.true_airspeed = 100.0
+    assert isinstance(atm.true_airspeed, float)
+
 
 def test_speed_conversions_with_broadcast():
     """Tests for speed conversions with different but compatible shapes for altitude and TAS"""

--- a/src/stdatm/tests/test_atmosphere.py
+++ b/src/stdatm/tests/test_atmosphere.py
@@ -12,7 +12,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from numbers import Number
+from numbers import Real
 
 import numpy as np
 import pytest
@@ -87,7 +87,7 @@ def test_atmosphere():
     for values in expectations:
         # Checking with altitude provided as scalar and delta_t as one-element array
         alt = values["alt"] / foot
-        assert isinstance(alt, Number)
+        assert isinstance(alt, Real)
         atm = Atmosphere(alt, np.array([values["dT"]]))
         assert values["T"] == pytest.approx(atm.temperature, rel=1e-4)
         assert values["rho"] == pytest.approx(atm.density, rel=1e-3)


### PR DESCRIPTION
This PR provides v0.3.1 as a hot fix.

Speed parameters were always converted to numpy arrays, even if provided as floats.

Draft release: https://github.com/fast-aircraft-design/StdAtm/releases/tag/untagged-78b82a5b750c9df5fa29
